### PR TITLE
KBC-2415 Add phpdoc to Keboola/DebugLogUploader/UploaderInterface

### DIFF
--- a/src/Keboola/DebugLogUploader/UploaderInterface.php
+++ b/src/Keboola/DebugLogUploader/UploaderInterface.php
@@ -4,9 +4,18 @@ namespace Keboola\DebugLogUploader;
 
 interface UploaderInterface
 {
+    /**
+     * @return string path to the uploaded resource
+     */
     public function upload($filePath, $contentType = 'text/plain');
 
+    /**
+     * @return string path to the uploaded resource
+     */
     public function uploadString($name, $content, $contentType = 'text/plain');
 
+    /**
+     * @return string
+     */
     public function getFilePathAndUniquePrefix();
 }


### PR DESCRIPTION
The lib has 5.4 requirements (syrup?) but the interface can still have at least PHPDoc typehints